### PR TITLE
Ignore Original OECD Files Folder

### DIFF
--- a/PIAAC/getData.R
+++ b/PIAAC/getData.R
@@ -89,3 +89,7 @@ for (i in 3:length(sheetList)) {
         fwrite(sheetList[[i]], paste0(excelSheetNames[i], ".csv"))
 }
 setwd(myDir)
+
+# -----------------------------------------------------------------------------
+## After solving Java problem: I can also other packages:
+## xlsx, XLConnect, openxls and compare it to readxl


### PR DESCRIPTION
After installed JRE legacy version on macOS Sierra I can now sort with other packages to read/write xlsx-files (xlsx, XLConnect).